### PR TITLE
Add PSB file type for future manifests

### DIFF
--- a/lib/object_photography_batch.rb
+++ b/lib/object_photography_batch.rb
@@ -94,6 +94,7 @@ class ObjectPhotographyBatch < Batch
       [
         ".dng", # image/x-adobe-dng,
         ".jpg", # image/jpeg,
+        ".psb", # Photoshop large format
         ".psd", # Photoshop masters
         ".tif", # image/tiff,
         ".tiff", # image/tiff,


### PR DESCRIPTION
Adds the extension PSB alongside PSD for large native images as an allowed format for Object Photography