### PR TITLE
Import accession numbers into SQLite lookup table

### DIFF
--- a/bin/import-accession-numbers.rb
+++ b/bin/import-accession-numbers.rb
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+#
+# import-accession-numbers.rb
+# 
+# Takes a data dump from Athena and converts into a reusable lookup table
+# for other scripts to use when doing validation agasint currently active
+# accession numbers. To use the results include the libraries 'sequel' and
+# 'sqlite3' 
+#
+# To run the import execute
+# bin/import-accession-numbers.rb [csv] [database]
+#
+# where 
+# [csv] corresponds to a comma delimited list of keys, numbers, and types
+# [database] corresponds to a stateless SQLite file on disk
+$:.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+
+require 'athena_processor'
+require 'sequel'
+
+def initialize_database db
+  @database = Sequel.sqlite(database: db)
+  @database.create_table? :accessions do
+    primary_key :id
+    String :accession_number
+    String :category
+  end
+end
+
+csv_input = ARGV[0]
+db_output = ARGV[1].nil? ? "accession_numbers.db" : ARGV[1]
+
+initialize_database db_output
+processor = AthenaProcessor.new csv_input
+processor.import_to @database[:accessions]

--- a/bin/import-photostudio-data.rb
+++ b/bin/import-photostudio-data.rb
@@ -14,7 +14,7 @@
 # present it will default to photostudio.db
 $:.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 
-require 'csv_importer'
+require 'photostudio_csv'
 require 'sequel'
 
 def initialize_database db_path
@@ -33,5 +33,5 @@ csv_path = ARGV[0]
 db_path = ARGV[1].nil? ? "photostudio.db" : ARGV[1]
 
 initialize_database db_path
-csv_processor = CsvImporter.new csv_path
-csv_processor.import_to @database[:sources]
+processor = PhotostudioProcessor.new csv_path
+processor.import_to @database[:sources]

--- a/lib/athena_processor.rb
+++ b/lib/athena_processor.rb
@@ -1,0 +1,34 @@
+require 'csv'
+require 'sequel'
+
+class AthenaProcessor
+  attr_accessor :csv_path
+
+  def initialize csv
+    if File.exists? csv
+      self.csv_path = csv
+    else
+      raise FileNotFoundError.new("Could not locate #{csv}")
+    end
+  end
+
+  def import_to database
+    database = Sequel.sqlite(database: database)
+    require 'athena_record'
+
+    metadata = CSV.read(csv_path, {headers: false, encoding: "ISO-8859-1"})
+    metadata.each_with_index do |csv, i|
+      puts "[#{i} / #{metadata.count}] #{csv[1]}"
+     
+      AthenaRecord.update_or_create({ 
+        accession_number: csv[1], 
+      }, { 
+        accession_number: csv[1],
+        category: csv[2] 
+      }) 
+    end
+  end
+end
+
+class FileNotFoundError < RuntimeError
+end

--- a/lib/athena_record.rb
+++ b/lib/athena_record.rb
@@ -1,0 +1,6 @@
+require 'sequel'
+
+class AthenaRecord < Sequel::Model(:accessions)
+  SEQUEL_NO_ASSOCIATIONS = true
+  Sequel::Model.plugin :update_or_create
+end

--- a/lib/photostudio_processor.rb
+++ b/lib/photostudio_processor.rb
@@ -1,7 +1,7 @@
 require 'csv'
 require 'sequel'
 
-class CsvImporter
+class PhotostudioProcessor
   attr_accessor :csv_path
 
   def initialize csv
@@ -14,14 +14,14 @@ class CsvImporter
 
   def import_to database
     database = Sequel.sqlite(database: database)
-    require 'photostudio_record'
+    require 'database_record'
 
     metadata = CSV.read(csv_path, {headers: true, header_converters: :symbol,
       encoding: "ISO-8859-1"})
     metadata.each_with_index do |csv, i|
       puts "[#{i} / #{metadata.count}] #{csv[:accession_]}"
      
-      PhotostudioRecord.update_or_create({ 
+      DatabaseRecord.update_or_create({ 
         accession_master: csv[:accession_], 
         dvd: csv[:dvd] 
       }, { 


### PR DESCRIPTION
Add support for Athena dumps starting with accession numbers. Additional information can be pulled via API on an as needed basis