### PR TITLE
Use new syntax with assumptions about database name

### DIFF
--- a/bin/prepare-object-batch.rb
+++ b/bin/prepare-object-batch.rb
@@ -13,7 +13,6 @@ batches = Dir.glob(File.expand_path(dropbox) + "/**/").select do |path|
 end
 batches.each do |batch|
   object_batch = ObjectPhotographyBatch.new
-  object_batch.load_photostudio_db "photostudio.db"
   object_batch.process batch
   object_batch.manifest "#{batch}#{File::Separator}batch.csv" if object_batch.has_files?
 end

--- a/lib/object_photography_batch.rb
+++ b/lib/object_photography_batch.rb
@@ -1,5 +1,6 @@
 require 'batch'
 require 'sequel'
+require 'photostudio_record'
 
 class ObjectPhotographyBatch < Batch
   attr :database
@@ -22,7 +23,6 @@ class ObjectPhotographyBatch < Batch
         dvd.sub!("DVD", "")
       end
 
-      require 'photostudio_record'
       metadata = PhotostudioRecord.where(accession_master: accession_master,
         dvd: dvd).first
       unless metadata.nil?
@@ -72,17 +72,6 @@ class ObjectPhotographyBatch < Batch
   def is_parseable? title
     ((0 == (/^DVD\d{4}/ =~ title)) ||
      (title.start_with? "WIB"))
-  end
-
-  def load_photostudio_db path
-    @database = Sequel.sqlite(database: path)
-    
-    if not @database.table_exists? :sources
-      raise RuntimeError.new "Table sources could not be found"
-    end
-
-    require 'photostudio_record'
-    PhotostudioRecord.db = @database
   end
 
   protected

--- a/lib/photostudio_record.rb
+++ b/lib/photostudio_record.rb
@@ -1,6 +1,7 @@
 require 'sequel'
 
-class PhotostudioRecord < Sequel::Model(:sources)
+DB = Sequel.connect('sqlite://photostudio.db')
+class PhotostudioRecord < Sequel::Model(DB[:sources])
   SEQUEL_NO_ASSOCIATIONS = true
   Sequel::Model.plugin :update_or_create
 end


### PR DESCRIPTION
This is a fix for https://github.com/ClevelandMuseumArt/cma-archives-utils/issues/15

It now assumes that the database, **photostudio.db**, will always be located in the same directory. If no database is present the script will fail immediately upon trying to require photostudio_record.