### PR TITLE
Report code coverage for better tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 spec/stdout.txt
 spec/stderr.txt
+coverage/
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start
+
 RSpec.configure do |config|
   config.add_formatter :documentation
 


### PR DESCRIPTION
Use SimpleCov to report code coverage and make sure there are no gaps when doing development work